### PR TITLE
Added flexibility to transform x-axis and color scale in rank_scatter

### DIFF
--- a/datasets/R/rank_scatter.R
+++ b/datasets/R/rank_scatter.R
@@ -1,9 +1,8 @@
-#' Rank scatter plots
+#' Scatter plots (p-value vs covariate)
 #' 
-#' Function to plot a scatter plot of the covariate rank by the -log10 p-value
+#' Function to plot a scatter plot of the covariate by the -log10 p-value
 #'
-#' The rank scatter function takes as input a data frame and the 
-#' covariate of interest
+#' This function takes as input a data frame and the covariate of interest
 #' and outputs a ggplot object that displays a scatter plot of the covariate
 #' rank versus the -log10 p-value.
 #' It also takes as input the number of bins for geom_hex
@@ -15,16 +14,23 @@
 #' @param covariate character that defines the name of the column in `dat` that 
 #'  contains the covariate
 #' @param bins a numeric value passed as the bins parameter for geom_hex
+#' @param funx function to transform the x-axis
+#' @param funfill function from the scales package to transform the color scale 
 #' 
 #' @return a ggplot object 
 #' 
 #' @author Keegan Korthauer      
-rank_scatter <- function(dat, pval, covariate, bins=100){
-  gg_scat <- ggplot(dat, aes(y=-log10(get("pval")), 
-                             x=rank(get(covariate), ties="first")/nrow(dat))) +
-    geom_hex(bins = bins) +
+rank_scatter <- function( dat, pval, covariate,bins=100,
+                         funx=function(x){rank(x, ties="first")/nrow(dat)},
+                         funfill=NULL )
+{
+  gg_scat <- ggplot(dat, aes(y=-log10(get(pval)), x=funx(get(covariate)))) +
+    geom_hex(bins = bins)+
     ylab(expression(-log[10]~p)) +
-    xlab("Covariate Rank")
-  theme_classic()
+    xlab("Covariate") +
+    theme_classic()
+  if( !is.null( funfill ) ){
+    gg_scat <- gg_scat + scale_fill_continuous(trans=funfill)
+  }
   return(gg_scat)
 }


### PR DESCRIPTION
I modified the `rank_scatter` function so we could transform the x-axis and the color scales passing parameters to this function. I noticed that using rank and normal scale was not the best for GSEA but I think it makes sense to use the same function. The defaults should behave as previously, so it should not break any code.